### PR TITLE
Feature/concurrent queries

### DIFF
--- a/docs/DatabaseClient.md
+++ b/docs/DatabaseClient.md
@@ -140,6 +140,8 @@ await query_results.consume()
 print(len(results))  ## 9 (if the database was empty before)
 ```
 
+Avoid running queries concurrently in one batch, as it is not an intended behavior of queries inside a transaction, and may lead to your code being stuck.
+
 Non-batch queries are concurrent by default.
 
 ### Using bookmarks (Enterprise Edition only)

--- a/docs/DatabaseClient.md
+++ b/docs/DatabaseClient.md
@@ -112,6 +112,36 @@ async with client.batch():
 
 You can batch anything that runs a query, be that a model method, a custom query or a relationship-property method. If any of the queries fail, the whole transaction will be rolled back and an exception will be raised.
 
+For batching in queries, that you want to execute concurrently with other `neo4j` transactions, use `client.concurrent_batch()` and pass it's return value into any model method, custom query or relationship-property method as arg `batch_manager`
+
+```python
+coroutines_count = 3
+queries_by_batch = 3
+coroutines = []
+
+async def batch_query(n):
+    async with client.concurrent_batch() as batch:
+        for i in range(queries_by_batch):
+            await client.cypher(
+                query="CREATE (d:Developer {uid: $uid, name: $name, age: $age})",
+                parameters={"uid": uuid.uuid4(), "name": f"Dev {n}{i}", "age": 25+i},
+                batch_manager=batch
+            )
+
+for i in range(coroutines_count):
+    coroutines.append(
+        batch_query(i)
+    )
+await asyncio.gather(*coroutines)
+query_results = await session.run("MATCH (n) RETURN n")
+results = await query_results.values()
+await query_results.consume()
+
+print(len(results))  ## 9 (if the database was empty before)
+```
+
+Non-batch queries are concurrent by default.
+
 ### Using bookmarks (Enterprise Edition only)
 
 If you are using the Enterprise Edition of Neo4j, you can use bookmarks to keep track of the last transaction that has been committed. The client provides a `last_bookmarks` property that allows you to get the bookmarks from the last session. These bookmarks can be used in combination with the `use_bookmarks()` method. Like the `batch()` method, the `use_bookmarks()` method has to be called with a context manager. All queries run inside the context manager will use the bookmarks passed to the `use_bookmarks()` method. Here is an example of how to use bookmarks:

--- a/pyneo4j_ogm/core/node.py
+++ b/pyneo4j_ogm/core/node.py
@@ -54,8 +54,10 @@ from pyneo4j_ogm.queries.types import (
 
 if TYPE_CHECKING:
     from pyneo4j_ogm.fields.relationship_property import RelationshipProperty
+    from pyneo4j_ogm.core.client import BatchManager
 else:
     RelationshipProperty = object
+    BatchManager = object
 
 P = ParamSpec("P")
 T = TypeVar("T", bound="NodeModel")
@@ -163,7 +165,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
             cls._register_relationship_properties()
 
     @hooks
-    async def create(self: T) -> T:
+    async def create(self: T, batch_manager: Optional[BatchManager] = None) -> T:
         """
         Creates a new node from the current instance. After the method is finished, a newly created
         instance is seen as `hydrated` and all methods can be called on it.
@@ -190,6 +192,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN n
             """,
             parameters=deflated_properties,
+            batch_manager=batch_manager,
         )
 
         logger.debug("Checking if query returned a result")
@@ -210,7 +213,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @hooks
     @ensure_alive
-    async def update(self) -> None:
+    async def update(self, batch_manager: Optional[BatchManager] = None) -> None:
         """
         Updates the corresponding node in the graph with the current instance values.
 
@@ -242,6 +245,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN n
             """,
             parameters={"element_id": self._element_id, **deflated},
+            batch_manager=batch_manager,
         )
 
         logger.debug("Checking if query returned a result")
@@ -254,7 +258,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @hooks
     @ensure_alive
-    async def delete(self) -> None:
+    async def delete(self, batch_manager: Optional[BatchManager] = None) -> None:
         """
         Deletes the corresponding node in the graph and marks this instance as destroyed. If
         another method is called on this instance, an `InstanceDestroyed` will be raised.
@@ -271,6 +275,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN count(n)
             """,
             parameters={"element_id": self._element_id},
+            batch_manager=batch_manager,
         )
 
         # If the returned value is empty, the node does not exist and the query failed
@@ -284,7 +289,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @hooks
     @ensure_alive
-    async def refresh(self) -> None:
+    async def refresh(self, batch_manager: Optional[BatchManager] = None) -> None:
         """
         Refreshes the current instance with the corresponding values from the graph.
 
@@ -299,6 +304,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN n
             """,
             parameters={"element_id": self._element_id},
+            batch_manager=batch_manager,
         )
 
         # If the returned value is empty, we can not refresh the instance
@@ -320,6 +326,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         options: Optional[QueryOptions] = None,
         auto_fetch_nodes: Optional[bool] = None,
         auto_fetch_models: Optional[List[Union[str, Type["NodeModel"]]]] = None,
+        batch_manager: Optional[BatchManager] = None,
     ) -> List[Union["NodeModel", Dict[str, Any]]]:
         """
         Gets all connected nodes which match the provided `filters` parameter over multiple hops.
@@ -334,6 +341,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 identical option defined in `Settings`. Defaults to `None`.
             auto_fetch_models (List[Union[str, Type["NodeModel"]]], optional): A list of models to auto-fetch.
                 `auto_fetch_nodes` has to be set to `True` for this to have any effect. Defaults to `[]`.
+            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
+                Defaults to `None`.
 
         Raises:
             InvalidFilters: If auto-fetch is enabled and no node labels are provided.
@@ -415,6 +424,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 "element_id": self._element_id,
                 **self._query_builder.parameters,
             },
+            batch_manager=batch_manager,
         )
 
         instances: List[Union["NodeModel", Dict[str, Any]]] = []
@@ -479,6 +489,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         auto_fetch_nodes: Optional[bool] = None,
         auto_fetch_models: Optional[List[Union[str, Type["NodeModel"]]]] = None,
         raise_on_empty: bool = False,
+        batch_manager: Optional[BatchManager] = None,
     ) -> Optional[Union[T, Dict[str, Any]]]:
         """
         Finds the first node that matches `filters` and returns it. If no matching node is found,
@@ -495,6 +506,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 `auto_fetch_nodes` has to be set to `True` for this to have any effect. Defaults to `[]`.
             raise_on_empty (bool, optional): Whether to raise an `NoResultFound` if no match is found. Defaults to
                 `False`.
+            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
+                Defaults to `None`.
 
         Raises:
             InvalidFilters: If no filters or invalid filters are provided.
@@ -544,6 +557,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                     {projection_query}, {', '.join(return_queries)}
                 """,
                 parameters=cls._query_builder.parameters,
+                batch_manager=batch_manager,
             )
         else:
             logger.debug("Querying database without auto-fetch")
@@ -561,6 +575,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                     LIMIT 1
                 """,
                 parameters=cls._query_builder.parameters,
+                batch_manager=batch_manager,
             )
 
         logger.debug("Checking if query returned a result")
@@ -612,6 +627,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         options: Optional[QueryOptions] = None,
         auto_fetch_nodes: Optional[bool] = None,
         auto_fetch_models: Optional[List[Union[str, Type["NodeModel"]]]] = None,
+        batch_manager: Optional[BatchManager] = None,
     ) -> List[Union[T, Dict[str, Any]]]:
         """
         Finds the all nodes that matches `filters` and returns them. If no matches are found, an
@@ -627,6 +643,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 identical option defined in `Settings`. Defaults to `None`.
             auto_fetch_models (List[Union[str, Type["NodeModel"]]], optional): A list of models to auto-fetch.
                 `auto_fetch_nodes` has to be set to `True` for this to have any effect. Defaults to `[]`.
+            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
+                Defaults to `None`.
 
         Returns:
             List[T | Dict[str, Any]]: A list of model instances or dictionaries of the projected properties.
@@ -668,6 +686,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                     {projection_query}, {', '.join(return_queries)}
                 """,
                 parameters=cls._query_builder.parameters,
+                batch_manager=batch_manager,
             )
 
             # Add auto-fetched nodes to relationship properties and keep track of which nodes
@@ -716,6 +735,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                     {projection_query}
                 """,
                 parameters=cls._query_builder.parameters,
+                batch_manager=batch_manager,
             )
 
             for result_list in results:
@@ -732,7 +752,12 @@ class NodeModel(ModelBase[NodeModelSettings]):
     @classmethod
     @hooks
     async def update_one(
-        cls: Type[T], update: Dict[str, Any], filters: NodeFilters, new: bool = False, raise_on_empty: bool = False
+        cls: Type[T],
+        update: Dict[str, Any],
+        filters: NodeFilters,
+        new: bool = False,
+        raise_on_empty: bool = False,
+        batch_manager: Optional[BatchManager] = None,
     ) -> Optional[T]:
         """
         Finds the first node that matches `filters` and updates it with the values defined by
@@ -780,6 +805,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 LIMIT 1
             """,
             parameters=cls._query_builder.parameters,
+            batch_manager=batch_manager,
         )
 
         logger.debug("Checking if query returned a result")
@@ -816,6 +842,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 {f"SET {set_query}" if set_query != "" else ""}
             """,
             parameters={"element_id": new_instance._element_id, **deflated},
+            batch_manager=batch_manager,
         )
         logger.debug("Successfully updated node %s", getattr(new_instance, "_element_id"))
 
@@ -831,6 +858,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         update: Dict[str, Any],
         filters: Optional[NodeFilters] = None,
         new: bool = False,
+        batch_manager: Optional[BatchManager] = None,
     ) -> List[T]:
         """
         Finds all nodes that match `filters` and updates them with the values defined by `update`.
@@ -840,6 +868,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
             filters (NodeFilters, optional): The filters to apply to the query. Defaults to `None`.
             new (bool, optional): Whether to return the updated nodes. By default, the old nodes
                 is returned. Defaults to `False`.
+            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
+                Defaults to `None`.
 
         Returns:
             List[T]: By default, the old node instances are returned. If `new` is set to `True`,
@@ -860,6 +890,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN DISTINCT n
             """,
             parameters=cls._query_builder.parameters,
+            batch_manager=batch_manager,
         )
 
         old_instances: List[T] = []
@@ -894,6 +925,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN DISTINCT n
             """,
             parameters={**deflated_properties, **cls._query_builder.parameters},
+            batch_manager=batch_manager,
         )
 
         logger.debug(
@@ -914,7 +946,12 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @classmethod
     @hooks
-    async def delete_one(cls: Type[T], filters: NodeFilters, raise_on_empty: bool = False) -> int:
+    async def delete_one(
+        cls: Type[T],
+        filters: NodeFilters,
+        raise_on_empty: bool = False,
+        batch_manager: Optional[BatchManager] = None
+    ) -> int:
         """
         Finds the first node that matches `filters` and deletes it. If no match is found, a
         `UnexpectedEmptyResult` is raised.
@@ -923,6 +960,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
             filters (NodeFilters): The filters to apply to the query.
             raise_on_empty (bool, optional): Whether to raise an `NoResultFound` if no match is found. Defaults to
                 `False`.
+            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
+                Defaults to `None`.
 
         Raises:
             UnexpectedEmptyResult: If the query should return a result but does not.
@@ -953,6 +992,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN count(n)
             """,
             parameters=cls._query_builder.parameters,
+            batch_manager=batch_manager,
         )
 
         logger.debug("Checking if query returned a result")
@@ -966,12 +1006,18 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @classmethod
     @hooks
-    async def delete_many(cls: Type[T], filters: Optional[NodeFilters] = None) -> int:
+    async def delete_many(
+        cls: Type[T],
+        filters: Optional[NodeFilters] = None,
+        batch_manager: Optional[BatchManager] = None
+    ) -> int:
         """
         Finds all nodes that match `filters` and deletes them.
 
         Args:
             filters (NodeFilters, optional): The filters to apply to the query. Defaults to `None`.
+            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
+                Defaults to `None`.
 
         Returns:
             int: The number of deleted nodes.
@@ -989,6 +1035,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN count(n)
             """,
             parameters=cls._query_builder.parameters,
+            batch_manager=batch_manager,
         )
 
         logger.debug("Checking if query returned a result")
@@ -1000,12 +1047,18 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @classmethod
     @hooks
-    async def count(cls: Type[T], filters: Optional[NodeFilters] = None) -> int:
+    async def count(
+        cls: Type[T],
+        filters: Optional[NodeFilters] = None,
+        batch_manager: Optional[BatchManager] = None
+    ) -> int:
         """
         Counts all nodes which match the provided `filters` parameter.
 
         Args:
             filters (NodeFilters, optional): The filters to apply to the query. Defaults to `None`.
+            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
+                Defaults to `None`.
 
         Returns:
             int: The number of nodes matched by the query.
@@ -1026,6 +1079,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 RETURN count(n)
             """,
             parameters=cls._query_builder.parameters,
+            batch_manager=batch_manager,
         )
 
         logger.debug("Checking if query returned a result")

--- a/pyneo4j_ogm/core/node.py
+++ b/pyneo4j_ogm/core/node.py
@@ -54,10 +54,10 @@ from pyneo4j_ogm.queries.types import (
 
 if TYPE_CHECKING:
     from pyneo4j_ogm.fields.relationship_property import RelationshipProperty
-    from pyneo4j_ogm.core.client import BatchManager
+    from pyneo4j_ogm.core.client import BatchManagerConcurrent
 else:
     RelationshipProperty = object
-    BatchManager = object
+    BatchManagerConcurrent = object
 
 P = ParamSpec("P")
 T = TypeVar("T", bound="NodeModel")
@@ -165,10 +165,14 @@ class NodeModel(ModelBase[NodeModelSettings]):
             cls._register_relationship_properties()
 
     @hooks
-    async def create(self: T, batch_manager: Optional[BatchManager] = None) -> T:
+    async def create(self: T, batch_manager: Optional[BatchManagerConcurrent] = None) -> T:
         """
         Creates a new node from the current instance. After the method is finished, a newly created
         instance is seen as `hydrated` and all methods can be called on it.
+
+        Args:
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Raises:
             UnexpectedEmptyResult: If the query should return a result but does not.
@@ -213,9 +217,13 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @hooks
     @ensure_alive
-    async def update(self, batch_manager: Optional[BatchManager] = None) -> None:
+    async def update(self, batch_manager: Optional[BatchManagerConcurrent] = None) -> None:
         """
         Updates the corresponding node in the graph with the current instance values.
+
+        Args:
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Raises:
             UnexpectedEmptyResult: If the query should return a result but does not.
@@ -258,10 +266,14 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @hooks
     @ensure_alive
-    async def delete(self, batch_manager: Optional[BatchManager] = None) -> None:
+    async def delete(self, batch_manager: Optional[BatchManagerConcurrent] = None) -> None:
         """
         Deletes the corresponding node in the graph and marks this instance as destroyed. If
         another method is called on this instance, an `InstanceDestroyed` will be raised.
+
+        Args:
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Raises:
             UnexpectedEmptyResult: If the query should return a result but does not.
@@ -289,9 +301,13 @@ class NodeModel(ModelBase[NodeModelSettings]):
 
     @hooks
     @ensure_alive
-    async def refresh(self, batch_manager: Optional[BatchManager] = None) -> None:
+    async def refresh(self, batch_manager: Optional[BatchManagerConcurrent] = None) -> None:
         """
         Refreshes the current instance with the corresponding values from the graph.
+
+        Args:
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Raises:
             UnexpectedEmptyResult: If the query should return a result but does not.
@@ -326,7 +342,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         options: Optional[QueryOptions] = None,
         auto_fetch_nodes: Optional[bool] = None,
         auto_fetch_models: Optional[List[Union[str, Type["NodeModel"]]]] = None,
-        batch_manager: Optional[BatchManager] = None,
+        batch_manager: Optional[BatchManagerConcurrent] = None,
     ) -> List[Union["NodeModel", Dict[str, Any]]]:
         """
         Gets all connected nodes which match the provided `filters` parameter over multiple hops.
@@ -341,8 +357,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 identical option defined in `Settings`. Defaults to `None`.
             auto_fetch_models (List[Union[str, Type["NodeModel"]]], optional): A list of models to auto-fetch.
                 `auto_fetch_nodes` has to be set to `True` for this to have any effect. Defaults to `[]`.
-            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
-                Defaults to `None`.
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+            batch queries. Defaults to `None`.
 
         Raises:
             InvalidFilters: If auto-fetch is enabled and no node labels are provided.
@@ -489,7 +505,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         auto_fetch_nodes: Optional[bool] = None,
         auto_fetch_models: Optional[List[Union[str, Type["NodeModel"]]]] = None,
         raise_on_empty: bool = False,
-        batch_manager: Optional[BatchManager] = None,
+        batch_manager: Optional[BatchManagerConcurrent] = None,
     ) -> Optional[Union[T, Dict[str, Any]]]:
         """
         Finds the first node that matches `filters` and returns it. If no matching node is found,
@@ -506,8 +522,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 `auto_fetch_nodes` has to be set to `True` for this to have any effect. Defaults to `[]`.
             raise_on_empty (bool, optional): Whether to raise an `NoResultFound` if no match is found. Defaults to
                 `False`.
-            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
-                Defaults to `None`.
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Raises:
             InvalidFilters: If no filters or invalid filters are provided.
@@ -627,7 +643,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         options: Optional[QueryOptions] = None,
         auto_fetch_nodes: Optional[bool] = None,
         auto_fetch_models: Optional[List[Union[str, Type["NodeModel"]]]] = None,
-        batch_manager: Optional[BatchManager] = None,
+        batch_manager: Optional[BatchManagerConcurrent] = None,
     ) -> List[Union[T, Dict[str, Any]]]:
         """
         Finds the all nodes that matches `filters` and returns them. If no matches are found, an
@@ -643,8 +659,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
                 identical option defined in `Settings`. Defaults to `None`.
             auto_fetch_models (List[Union[str, Type["NodeModel"]]], optional): A list of models to auto-fetch.
                 `auto_fetch_nodes` has to be set to `True` for this to have any effect. Defaults to `[]`.
-            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
-                Defaults to `None`.
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Returns:
             List[T | Dict[str, Any]]: A list of model instances or dictionaries of the projected properties.
@@ -757,7 +773,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         filters: NodeFilters,
         new: bool = False,
         raise_on_empty: bool = False,
-        batch_manager: Optional[BatchManager] = None,
+        batch_manager: Optional[BatchManagerConcurrent] = None,
     ) -> Optional[T]:
         """
         Finds the first node that matches `filters` and updates it with the values defined by
@@ -858,7 +874,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         update: Dict[str, Any],
         filters: Optional[NodeFilters] = None,
         new: bool = False,
-        batch_manager: Optional[BatchManager] = None,
+        batch_manager: Optional[BatchManagerConcurrent] = None,
     ) -> List[T]:
         """
         Finds all nodes that match `filters` and updates them with the values defined by `update`.
@@ -868,8 +884,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
             filters (NodeFilters, optional): The filters to apply to the query. Defaults to `None`.
             new (bool, optional): Whether to return the updated nodes. By default, the old nodes
                 is returned. Defaults to `False`.
-            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
-                Defaults to `None`.
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Returns:
             List[T]: By default, the old node instances are returned. If `new` is set to `True`,
@@ -950,7 +966,7 @@ class NodeModel(ModelBase[NodeModelSettings]):
         cls: Type[T],
         filters: NodeFilters,
         raise_on_empty: bool = False,
-        batch_manager: Optional[BatchManager] = None
+        batch_manager: Optional[BatchManagerConcurrent] = None
     ) -> int:
         """
         Finds the first node that matches `filters` and deletes it. If no match is found, a
@@ -960,8 +976,8 @@ class NodeModel(ModelBase[NodeModelSettings]):
             filters (NodeFilters): The filters to apply to the query.
             raise_on_empty (bool, optional): Whether to raise an `NoResultFound` if no match is found. Defaults to
                 `False`.
-            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
-                Defaults to `None`.
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Raises:
             UnexpectedEmptyResult: If the query should return a result but does not.
@@ -1009,15 +1025,15 @@ class NodeModel(ModelBase[NodeModelSettings]):
     async def delete_many(
         cls: Type[T],
         filters: Optional[NodeFilters] = None,
-        batch_manager: Optional[BatchManager] = None
+        batch_manager: Optional[BatchManagerConcurrent] = None
     ) -> int:
         """
         Finds all nodes that match `filters` and deletes them.
 
         Args:
             filters (NodeFilters, optional): The filters to apply to the query. Defaults to `None`.
-            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
-                Defaults to `None`.
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Returns:
             int: The number of deleted nodes.
@@ -1050,15 +1066,15 @@ class NodeModel(ModelBase[NodeModelSettings]):
     async def count(
         cls: Type[T],
         filters: Optional[NodeFilters] = None,
-        batch_manager: Optional[BatchManager] = None
+        batch_manager: Optional[BatchManagerConcurrent] = None
     ) -> int:
         """
         Counts all nodes which match the provided `filters` parameter.
 
         Args:
             filters (NodeFilters, optional): The filters to apply to the query. Defaults to `None`.
-            batch_manager (BatchManager, optional): The batch manager to use for asyncio-safe concurrent batch queries.
-                Defaults to `None`.
+            batch_manager (BatchManagerConcurrent, optional): The batch manager to use for asyncio-safe concurrent
+                batch queries. Defaults to `None`.
 
         Returns:
             int: The number of nodes matched by the query.

--- a/pyneo4j_ogm/logger.py
+++ b/pyneo4j_ogm/logger.py
@@ -9,7 +9,7 @@ import logging
 from os import environ
 
 enable_logging = environ.get("PYNEO4J_OGM_ENABLE_LOGGING", "True").lower() == "true"
-log_level = int(environ.get("PYNEO4J_OGM_LOG_LEVEL", logging.WARNING))
+log_level = int(environ.get("PYNEO4J_OGM_LOG_LEVEL", logging.DEBUG))
 
 logger = logging.getLogger("pyneo4j-ogm")
 logger.setLevel(log_level)

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -1,6 +1,6 @@
 # pylint: disable=unused-argument, unused-import, redefined-outer-name, protected-access, missing-module-docstring, missing-class-docstring
 # pyright: reportGeneralTypeIssues=false
-
+import asyncio
 import os
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
@@ -47,9 +47,15 @@ class CypherResolvingRelationship(RelationshipModel):
 
 
 async def test_batch(client: Pyneo4jClient, session: AsyncSession):
-    async with client.batch():
-        await client.cypher("CREATE (n:Node) SET n.name = $name", parameters={"name": "TestName"})
-        await client.cypher("CREATE (n:Node) SET n.name = $name", parameters={"name": "TestName2"})
+    async with client.batch() as batch:
+        await client.cypher(
+            "CREATE (n:Node) SET n.name = $name", parameters={"name": "TestName"},
+            batch_manager=batch
+        )
+        await client.cypher(
+            "CREATE (n:Node) SET n.name = $name", parameters={"name": "TestName2"},
+            batch_manager=batch
+        )
 
     query_results = await session.run("MATCH (n) RETURN n")
     results = await query_results.values()
@@ -58,11 +64,59 @@ async def test_batch(client: Pyneo4jClient, session: AsyncSession):
     assert len(results) == 2
 
 
+async def test_concurrent_non_batch_execution(client: Pyneo4jClient, session: AsyncSession):
+    coroutines_count = 3
+    coroutines = []
+    for i in range(coroutines_count):
+        coroutines.append(
+            client.cypher("CREATE (n:Node) SET n.name = $name", parameters={"name": f"TestName{i}"},)
+        )
+    await asyncio.gather(*coroutines)
+    query_results = await session.run("MATCH (n) RETURN n")
+    results = await query_results.values()
+    await query_results.consume()
+
+    assert len(results) == coroutines_count
+
+
+async def test_concurrent_batch_execution(client: Pyneo4jClient, session: AsyncSession):
+    coroutines_count = 3
+    queries_by_batch = 3
+    coroutines = []
+
+    async def batch_query(n):
+        async with client.batch() as batch:
+            print(batch)
+            for j in range(queries_by_batch):
+                print(f"{n}{j}")
+                await client.cypher(
+                    "CREATE (n:Node) SET n.name = $name", parameters={"name": f"TestName{n}{j}"},
+                    batch_manager=batch
+                )
+
+    for i in range(coroutines_count):
+        coroutines.append(
+            batch_query(i)
+        )
+    await asyncio.gather(*coroutines)
+    query_results = await session.run("MATCH (n) RETURN n")
+    results = await query_results.values()
+    await query_results.consume()
+
+    assert len(results) == coroutines_count * queries_by_batch
+
+
 async def test_batch_exception(client: Pyneo4jClient, session: AsyncSession):
     with pytest.raises(Exception):
-        async with client.batch():
-            await client.cypher("CREATE (n:Node) SET n.name = $name", parameters={"name": "TestName"})
-            await client.cypher("CREATE (n:Node) SET n.name = $name", parameters={"name": "TestName2"})
+        async with client.batch() as batch:
+            await client.cypher(
+                "CREATE (n:Node) SET n.name = $name", parameters={"name": "TestName"},
+                batch_manager=batch
+            )
+            await client.cypher(
+                "CREATE (n:Node) SET n.name = $name", parameters={"name": "TestName"},
+                batch_manager=batch
+            )
 
             raise Exception("Test Exception")  # pylint: disable=broad-exception-raised
 
@@ -74,10 +128,9 @@ async def test_batch_exception(client: Pyneo4jClient, session: AsyncSession):
 
 
 async def test_transaction_in_progress_exception(client: Pyneo4jClient):
-    await client._begin_transaction()
-
-    with pytest.raises(TransactionInProgress):
-        await client._begin_transaction()
+    async with client.batch() as batch:
+        with pytest.raises(TransactionInProgress):
+            await batch._begin_transaction()
 
 
 async def test_connection():


### PR DESCRIPTION
Currently, concurrent queries raise `pyneo4j_ogm.exceptions.TransactionInProgress: A transaction is already in progress.`, for example, in the following cases:
1) asyncio.gather
```python
async def test_concurrent_non_batch_execution(client: Pyneo4jClient, session: AsyncSession):
    coroutines_count = 3
    coroutines = []
    for i in range(coroutines_count):
        coroutines.append(
            client.cypher("CREATE (n:Node) SET n.name = $name", parameters={"name": f"TestName{i}"},)
        )
    await asyncio.gather(*coroutines)
```
2) when different requests to api endpoints come up at the same time, and there's need to execute queries concurrently.

In this PR I made sort of workaroud, that includes:
- single query creates and stores transaction inside `client.cypher()` method, that allows them to be ran  concurrently
- batch query can gets batch transaction from instance of class `BatchManagerConcurrent`, that is instantiated by `client.concurrent_batch()` method and passed into any method anything that runs a query in optional (and None by default) field `batch_manager`
- for reverse compatibility old workflow is fully preserved

I look forward to using 1.0.0 version of this lib, and hope that you'll add features from this PR as minor improvement before major release and consider concepts from it for 1.0.0, alongside with Multithreading/Multiple clients support 